### PR TITLE
Update to use PBS default builder and run image

### DIFF
--- a/cmd/pbdemo/main.go
+++ b/cmd/pbdemo/main.go
@@ -43,12 +43,6 @@ func populateCmd() *cobra.Command {
 		Aliases: []string{"setup"},
 		Short:   "Populate Build Service with Images",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// fmt.Println("Relocating Builder and Run Image. This will take a moment.")
-
-			// relocated, err := populate.Relocate(registry)
-			// if err != nil {
-			// 	return err
-			// }
 			fmt.Println("using existing builder and run image")
 			populate.Populate(count, registry, cacheSize)
 			return nil

--- a/cmd/pbdemo/main.go
+++ b/cmd/pbdemo/main.go
@@ -43,14 +43,14 @@ func populateCmd() *cobra.Command {
 		Aliases: []string{"setup"},
 		Short:   "Populate Build Service with Images",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Println("Relocating Builder and Run Image. This will take a moment.")
+			// fmt.Println("Relocating Builder and Run Image. This will take a moment.")
 
-			relocated, err := populate.Relocate(registry)
-			if err != nil {
-				return err
-			}
-
-			populate.Populate(count, relocated.BuilderImage, registry, cacheSize)
+			// relocated, err := populate.Relocate(registry)
+			// if err != nil {
+			// 	return err
+			// }
+			fmt.Println("using existing builder and run image")
+			populate.Populate(count, registry, cacheSize)
 			return nil
 		},
 	}

--- a/defaults/demo.go
+++ b/defaults/demo.go
@@ -1,4 +1,4 @@
 package defaults
 
-const BuilderName = "demo-builder"
+const BuilderName = "build-service-cluster-builder"
 const Namespace = "demo-team"

--- a/populate/cleanup.go
+++ b/populate/cleanup.go
@@ -36,5 +36,5 @@ func Cleanup() error {
 		}
 	}
 
-	return client.BuildV1alpha1().ClusterBuilders().Delete(defaults.BuilderName, &metav1.DeleteOptions{})
+	return err
 }

--- a/populate/populate.go
+++ b/populate/populate.go
@@ -21,7 +21,7 @@ import (
 	"time"
 )
 
-func Populate(count int32, builder, registry, cacheSize string) {
+func Populate(count int32, registry, cacheSize string) {
 	clusterConfig, err := k8s.BuildConfigFromFlags("", "")
 	if err != nil {
 		log.Fatalf("Error building kubeconfig: %v", err)
@@ -76,38 +76,39 @@ func Populate(count int32, builder, registry, cacheSize string) {
 	noError(err)
 
 	const builderName = defaults.BuilderName
-	clusterBuilder, err := client.BuildV1alpha1().ClusterBuilders().Get(builderName, metav1.GetOptions{})
-	if err != nil && !errors.IsNotFound(err) {
-		noError(err)
-	}
+	// clusterBuilder, err := client.BuildV1alpha1().ClusterBuilders().Get(builderName, metav1.GetOptions{})
+	// if err != nil && !errors.IsNotFound(err) {
+	// 	noError(err)
+	// }
+	log.Printf("using builder %s", builderName)
 
-	if errors.IsNotFound(err) {
-		_, err = client.BuildV1alpha1().ClusterBuilders().Create(&v1alpha1.ClusterBuilder{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: builderName,
-			},
-			Spec: v1alpha1.BuilderSpec{
-				Image:        builder,
-				UpdatePolicy: v1alpha1.Polling,
-			},
-		})
-		if err != nil {
-			noError(err)
-		}
-	} else {
-		_, err = client.BuildV1alpha1().ClusterBuilders().Update(&v1alpha1.ClusterBuilder{
-			ObjectMeta: clusterBuilder.ObjectMeta,
-			Spec: v1alpha1.BuilderSpec{
-				Image:        builder,
-				UpdatePolicy: v1alpha1.Polling,
-			},
-		})
-		if err != nil && !errors.IsAlreadyExists(err) {
-			noError(err)
-		}
-	}
+	// if errors.IsNotFound(err) {
+	// 	_, err = client.BuildV1alpha1().ClusterBuilders().Create(&v1alpha1.ClusterBuilder{
+	// 		ObjectMeta: metav1.ObjectMeta{
+	// 			Name: builderName,
+	// 		},
+	// 		Spec: v1alpha1.BuilderSpec{
+	// 			Image:        builder,
+	// 			UpdatePolicy: v1alpha1.Polling,
+	// 		},
+	// 	})
+	// 	if err != nil {
+	// 		noError(err)
+	// 	}
+	// } else {
+	// 	_, err = client.BuildV1alpha1().ClusterBuilders().Update(&v1alpha1.ClusterBuilder{
+	// 		ObjectMeta: clusterBuilder.ObjectMeta,
+	// 		Spec: v1alpha1.BuilderSpec{
+	// 			Image:        builder,
+	// 			UpdatePolicy: v1alpha1.Polling,
+	// 		},
+	// 	})
+	// 	if err != nil && !errors.IsAlreadyExists(err) {
+	// 		noError(err)
+	// 	}
+	// }
 
-	updatePbBuilder(builder, client)
+	// updatePbBuilder(builder, client)
 
 	seed := time.Now().UTC().UnixNano()
 	nameGenerator := namegenerator.NewNameGenerator(seed)

--- a/populate/populate.go
+++ b/populate/populate.go
@@ -76,39 +76,9 @@ func Populate(count int32, registry, cacheSize string) {
 	noError(err)
 
 	const builderName = defaults.BuilderName
-	// clusterBuilder, err := client.BuildV1alpha1().ClusterBuilders().Get(builderName, metav1.GetOptions{})
-	// if err != nil && !errors.IsNotFound(err) {
-	// 	noError(err)
-	// }
+
 	log.Printf("using builder %s", builderName)
 
-	// if errors.IsNotFound(err) {
-	// 	_, err = client.BuildV1alpha1().ClusterBuilders().Create(&v1alpha1.ClusterBuilder{
-	// 		ObjectMeta: metav1.ObjectMeta{
-	// 			Name: builderName,
-	// 		},
-	// 		Spec: v1alpha1.BuilderSpec{
-	// 			Image:        builder,
-	// 			UpdatePolicy: v1alpha1.Polling,
-	// 		},
-	// 	})
-	// 	if err != nil {
-	// 		noError(err)
-	// 	}
-	// } else {
-	// 	_, err = client.BuildV1alpha1().ClusterBuilders().Update(&v1alpha1.ClusterBuilder{
-	// 		ObjectMeta: clusterBuilder.ObjectMeta,
-	// 		Spec: v1alpha1.BuilderSpec{
-	// 			Image:        builder,
-	// 			UpdatePolicy: v1alpha1.Polling,
-	// 		},
-	// 	})
-	// 	if err != nil && !errors.IsAlreadyExists(err) {
-	// 		noError(err)
-	// 	}
-	// }
-
-	// updatePbBuilder(builder, client)
 
 	seed := time.Now().UTC().UnixNano()
 	nameGenerator := namegenerator.NewNameGenerator(seed)

--- a/rebase/update_run_image.go
+++ b/rebase/update_run_image.go
@@ -38,7 +38,7 @@ func UpdateRunImage() error {
 		return err
 	}
 
-	runImage := fmt.Sprintf("%s/%s:pbdemo", reference.Context().RegistryStr(), reference.Context().RepositoryStr())
+	runImage := fmt.Sprintf("%s/%s:full-cnb", reference.Context().RegistryStr(), reference.Context().RepositoryStr())
 	fmt.Printf("Pushing update to: %s\n", runImage)
 
 	image, err := remote.NewImage(runImage, authn.DefaultKeychain, remote.FromBaseImage(builder.Status.Stack.RunImage))

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -2664,8 +2664,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -2683,13 +2682,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2702,18 +2699,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -2816,8 +2810,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -2827,7 +2820,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -2840,20 +2832,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -2870,7 +2859,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -2943,8 +2931,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -2954,7 +2941,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3030,8 +3016,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3061,7 +3046,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3079,7 +3063,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3118,13 +3101,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -6860,8 +6841,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -6879,13 +6859,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -6898,18 +6876,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -7012,8 +6987,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -7023,7 +6997,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -7036,20 +7009,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -7066,7 +7036,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -7139,8 +7108,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -7150,7 +7118,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -7226,8 +7193,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -7257,7 +7223,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -7275,7 +7240,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -7314,13 +7278,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         }


### PR DESCRIPTION
this PR updates `pbdemo` to use the default cluster builder provided by PBS. it also updates the run image to use the image provided by PBS. thsi enables pbdemo to rebase images managed by PBS.